### PR TITLE
Update xblock-utils dependency.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e .
 -e git://github.com/nosedjango/nosedjango.git@ed7d7f9aa969252ff799ec159f828eaa8c1cbc5a#egg=nosedjango-dev
--e git://github.com/open-craft/xblock-utils.git@51dc6f3bda190ec3f8910ce008817a9a558223dd#egg=xblock-utils
+-e git://github.com/edx-solutions/xblock-utils.git@7d7201fb2b0bfc8e5d13905d1cedf88335ab4a93#egg=xblock-utils
 lxml==3.0.1


### PR DESCRIPTION
xblockutils.resources namespace does not exist in the xblock-utils
version that was specified in requirements.txt, but image explorer needs it.

Point the dependency in requirements.txt to the latest version of the
repository under edx-solutions instead.
