### PR TITLE
Fixed overflow-y scroll bar that was always displayed on Windows

### DIFF
--- a/image_explorer/public/css/image_explorer.css
+++ b/image_explorer/public/css/image_explorer.css
@@ -15,7 +15,7 @@
     top: 25%;
     z-index: 2;
     display: none;
-    overflow-y: scroll;
+    overflow-y: auto;
     cursor: default;
 }
 


### PR DESCRIPTION
It was reported that on Windows OS overflow-y scroll bar is always displayed, even when the content height is small enough to fit well within the parent element.

This change seems to fix the issue. @antoviaque can you please take a peek.
