### PR TITLE
Fix for hot-spot sprite image not visible on production like environment

### DIFF
--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -99,20 +99,17 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
             if hotspot.feedback.youtube:
                 has_youtube = True
 
-        sprite_url = self.runtime.local_resource_url(self, 'public/images/hotspot-sprite.png')
-
         context = {
             'title': self.display_name,
             'description_html': description,
             'hotspots': hotspots,
             'background': background,
-            'sprite_url': sprite_url,
         }
 
         fragment = Fragment()
         fragment.add_content(loader.render_template('/templates/html/image_explorer.html', context))
-        fragment.add_css(loader.load_unicode('public/css/image_explorer.css'))
-        fragment.add_javascript(loader.load_unicode('public/js/image_explorer.js'))
+        fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/image_explorer.css'))
+        fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/image_explorer.js'))
         if has_youtube:
             fragment.add_javascript_url('https://www.youtube.com/iframe_api')
 
@@ -176,7 +173,7 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
         fragment.add_content(loader.render_template('/templates/html/image_explorer_edit.html', {
             'self': self,
         }))
-        fragment.add_javascript(loader.load_unicode('public/js/image_explorer_edit.js'))
+        fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/image_explorer_edit.js'))
 
         fragment.initialize_js('ImageExplorerEditBlock')
 

--- a/image_explorer/public/css/image_explorer.css
+++ b/image_explorer/public/css/image_explorer.css
@@ -35,7 +35,7 @@
 }
 
 .image-explorer-wrapper div.image-explorer-hotspot {
-    background: url("/static/images/image-explorer-hotspot-sprite.png") no-repeat scroll 0 0 rgba(0, 0, 0, 0);
+    background: url("../images/hotspot-sprite.png") no-repeat scroll 0 0 rgba(0, 0, 0, 0);
     width: 41px;
     height: 41px;
     display: block;

--- a/image_explorer/templates/html/image_explorer.html
+++ b/image_explorer/templates/html/image_explorer.html
@@ -9,7 +9,7 @@
     <div class="image-explorer-wrapper">
         <img src="{{background.src}}" class="image-explorer-background" />
         {% for hotspot in hotspots %}
-        <div class="image-explorer-hotspot" style="position: absolute; top: {{hotspot.y}}px; left: {{hotspot.x}}px; background-image: url('{{sprite_url}}')" data-item-id="{{hotspot.item_id}}">
+        <div class="image-explorer-hotspot" style="position: absolute; top: {{hotspot.y}}px; left: {{hotspot.x}}px;" data-item-id="{{hotspot.item_id}}">
                 <div class="image-explorer-hotspot-reveal" {{hotspot.reveal_style}} data-side="{{ hotspot.feedback.side }}">
                     <div class="image-explorer-close-reveal">&#xf057;</div>
                     <div class="image-explorer-hotspot-content-wrapper">


### PR DESCRIPTION
This PR address an issue where hot-spot sprite image not visible when assets are compiled on production environment.  Sprite url was generated with this statement
```
sprite_url = self.runtime.local_resource_url(self, 'public/images/hotspot-sprite.png')
```
which give and invalid url relevant to studio environment some like this (`/c4x/MMBA/IE230/asset/xblock_resources_image_explorer.image_explorer_public_images_hotspot-sprite.8e637638fd95.8e637638fd95.png`)

More detail of the issue can be found [here](https://openedx.atlassian.net/browse/YONK-478)

@bradenmacdonald can some one from you team review this?

