### PR TITLE
adds student_view_data to Image Explorer Block

### DIFF
--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -117,6 +117,23 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
 
         return fragment
 
+    def student_view_data(self, context=None):
+        """
+        Returns a JSON representation of the Image Explorer Xblock, that can be
+        retrieved using Course Block API.
+        """
+        xmltree = etree.fromstring(self.data)
+
+        description = self._get_description(xmltree)
+        background = self._get_background(xmltree)
+        hotspots = self._get_hotspots(xmltree)
+
+        return {
+            'description': description,
+            'background': background,
+            'hotspots': hotspots,
+        }
+
     @XBlock.json_handler
     def publish_event(self, data, suffix=''):
         try:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-image-explorer',
-    version='0.3',
+    version='0.4.0',
     description='XBlock - Image Explorer',
     packages=['image_explorer'],
     install_requires=[

--- a/tests/unit/test_image_explorer.py
+++ b/tests/unit/test_image_explorer.py
@@ -1,0 +1,60 @@
+import unittest
+from lxml import etree
+
+from xblock.field_data import DictFieldData
+
+from image_explorer.image_explorer import ImageExplorerBlock
+from ..utils import MockRuntime
+
+class TestImageExplorerBlock(unittest.TestCase):
+    """
+    Tests for XBlock Image Explorer.
+    """
+    def setUp(self):
+        """
+        Test case setup
+        """
+        super(TestImageExplorerBlock, self).setUp()
+        self.runtime = MockRuntime()
+        self.image_url = 'http://example.com/test.jpg'
+        self.image_explorer_description = '<p>Test Descrption</p>'
+        self.image_explorer_xml = """
+            <image_explorer schema_version='1'>
+                <background src='{0}' />
+                <description>{1}</description>
+                <hotspots>
+                    <hotspot x='370' y='20' item-id='hotspotA'>
+                        <feedback width='300' height='240'>
+                            <header><p>Test Header</p></header>
+                            <body><p>Test Body</p></body>
+                        </feedback>
+                    </hotspot>
+                </hotspots>
+            </image_explorer>
+            """.format(self.image_url, self.image_explorer_description)
+
+        self.image_explorer_data = {'data': self.image_explorer_xml}
+        self.image_explorer_block = ImageExplorerBlock(
+            self.runtime,
+            DictFieldData(self.image_explorer_data),
+            None
+        )
+
+    def test_student_view_data(self):
+        """
+        Test the student_view_data results.
+        """
+        xmltree = etree.fromstring(self.image_explorer_xml)
+        hotspots = self.image_explorer_block._get_hotspots(xmltree)
+        expected_image_explorer_data = {
+            'description': self.image_explorer_description,
+            'background': {
+                'src': self.image_url,
+                'height': None,
+                'width': None
+            },
+            'hotspots': hotspots,
+        }
+
+        student_view_data = self.image_explorer_block.student_view_data()
+        self.assertEqual(student_view_data, expected_image_explorer_data)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,12 @@
+# Test mocks and helpers
+from xblock.runtime import DictKeyValueStore, KvsFieldData
+from xblock.test.tools import TestRuntime
+
+
+class MockRuntime(TestRuntime):
+    """
+    Provides a mock XBlock runtime object.
+    """
+    def __init__(self, **kwargs):
+        field_data = kwargs.get('field_data', KvsFieldData(DictKeyValueStore()))
+        super(MockRuntime, self).__init__(field_data=field_data)


### PR DESCRIPTION
This PR adds student_view_data to Image Explorer Block which returns a JSON representation of the Image Explorer Xblock, that can be retrieved using Course Block API.

