### PR TITLE
HTML element parsing fix

### DIFF
--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -6,8 +6,7 @@
 import logging
 import textwrap
 import uuid
-from lxml import etree
-from xml.etree import ElementTree as ET
+from lxml import etree, html
 
 from xblock.core import XBlock
 from xblock.fields import List, Scope, String, Boolean
@@ -251,7 +250,7 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
         Helper met
         """
         if tag is not None:
-            return u''.join(ET.tostring(e) for e in tag)
+            return u''.join(html.tostring(e) for e in tag)
         return None
 
     def _get_description(self, xmltree):


### PR DESCRIPTION
**Problem**: We need to embed Ooyala external script file in the feedback of Image Explorer. The xml `ElementTree` does not parse it properly.
E.g; when using following content for feedback body tag
>
    <body>
      <script src="//player.ooyala.com/core/10efd95b66124001b415aa2a4bee29c8?plugins=main,bm"></script>
       <div id="ooyalaplayer_3" style="width: 320px; height: 180px;"></div>
                 <script>// <![CDATA[
                                $('#ooyalaplayer_3').closest('.image-explorer-hotspot').on('feedback:open', function(evt) {
                                OO.Player.create('ooyalaplayer_3', '13MWF0YzE6452Hges6wH8BPOXtQq10al');
                                }).on('feedback:close', function(evt) {
                                OO.Player.create('ooyalaplayer_3').pause();
                                });
                // ]]></script>

    </body>
it produces following HTML, and incorrectly wraps the subsequent text in the script tag. 
<img width="856" alt="HTML output" src="https://user-images.githubusercontent.com/6681794/36023437-3ea7d3aa-0dae-11e8-8c60-663a18b666c3.png">

**Solution**: Using `lxml.html` over `xml.etree` as html is more friendly regarding to html elements.