### PR TITLE
[MCKIN-2723] Needs i18n runtime service to provide translations for HTML templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,26 @@ advanced settings.
 Testing
 -------
 
-Make sure you have a python virtual environment with `xblock-sdk` version `0.1.5` or higher.
-
-To run all integration and unit tests, run:
+Make sure you have a python virtual environment with `xblock-sdk` version `0.1.5` or higher:
 
 ```bash
-DJANGO_SETTINGS_MODULE=workbench.settings django-admin.py test
+pip install -e git://github.com/edx/xblock-sdk.git#egg=xblock-sdk
+cd $VIRTUAL_ENV/src/xblock-sdk/ && make install && cd -
+pip install -r requirements.txt
 ```
 
-You may need to first install `geckodriver` on your system.
+To run the unit tests, run:
+
+```bash
+python run_tests.py tests/unit
+```
+
+To run the integration tests, you'll need [`geckodriver`](https://github.com/mozilla/geckodriver) and `xvfb` installed.
+
+```bash
+export DISPLAY=:99
+xvfb-run python run_tests.py tests/integration
+```
 
 Usage
 -----

--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -21,6 +21,7 @@ from .utils import loader, AttrDict, _
 log = logging.getLogger(__name__)
 
 
+@XBlock.needs('i18n')
 class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
     """
     XBlock that renders an image with tooltips
@@ -131,7 +132,9 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
         }
 
         fragment = Fragment()
-        fragment.add_content(loader.render_template('/templates/html/image_explorer.html', context))
+        fragment.add_content(loader.render_django_template('/templates/html/image_explorer.html',
+                                                           context=context,
+                                                           i18n_service=self.runtime.service(self, 'i18n')))
         fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/image_explorer.css'))
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/image_explorer.js'))
         if has_youtube:
@@ -216,9 +219,9 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
         Editing view in Studio
         """
         fragment = Fragment()
-        fragment.add_content(loader.render_template('/templates/html/image_explorer_edit.html', {
-            'self': self,
-        }))
+        fragment.add_content(loader.render_django_template('/templates/html/image_explorer_edit.html',
+                                                           context={'self': self},
+                                                           i18n_service=self.runtime.service(self, 'i18n')))
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/image_explorer_edit.js'))
 
         fragment.initialize_js('ImageExplorerEditBlock')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 -e .
-# FIXME -- bump version to 1.1.0 when https://github.com/edx/xblock-utils/pull/48 merged and tagged
-git+https://github.com/open-craft/xblock-utils.git@MCKIN-7023-template-i18n#egg=xblock-utils==1.1.0
+-e git+https://github.com/edx/xblock-utils.git@v1.1.0#egg=xblock-utils==1.1.0
 lxml==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 -e .
--e git://github.com/edx-solutions/xblock-utils.git@v1.0.5#egg=xblock-utils
+# FIXME -- bump version to 1.1.0 when https://github.com/edx/xblock-utils/pull/48 merged and tagged
+git+https://github.com/open-craft/xblock-utils.git@MCKIN-7023-template-i18n#egg=xblock-utils==1.1.0
 lxml==3.0.1

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Run tests for the Image Explorer XBlock
+
+This script is required to run our selenium tests inside the xblock-sdk workbench
+because the workbench SDK's settings file is not inside any python module.
+"""
+
+import os
+import sys
+import logging
+
+logging_level_overrides = {
+    'workbench.views': logging.ERROR,
+    'django.request': logging.ERROR,
+    'workbench.runtime': logging.ERROR,
+}
+
+if __name__ == "__main__":
+    # Use the workbench settings file:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "workbench.settings")
+    # Configure a range of ports in case the default port of 8081 is in use
+    os.environ.setdefault("DJANGO_LIVE_TEST_SERVER_ADDRESS", "localhost:8081-8099")
+
+    try:
+        os.mkdir('var')
+    except OSError:
+        # May already exist.
+        pass
+
+    from django.conf import settings
+    settings.INSTALLED_APPS += ("image_explorer", )
+
+    for noisy_logger, log_level in logging_level_overrides.iteritems():
+        logging.getLogger(noisy_logger).setLevel(log_level)
+
+    from django.core.management import execute_from_command_line
+    args = sys.argv[1:]
+    paths = [arg for arg in args if arg[0] != '-']
+    if not paths:
+        paths = ["tests"]
+    options = [arg for arg in args if arg not in paths]
+    execute_from_command_line([sys.argv[0], "test"] + paths + options)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-image-explorer',
-    version='0.9.0',
+    version='1.0.0',
     description='XBlock - Image Explorer',
     packages=['image_explorer'],
     install_requires=[


### PR DESCRIPTION
Once the dependent PRs are merged, this change is all that's required to allow this XBlock to use its own translations for text found in HTML templates.

**JIRA tickets**: [MCKIN-7023](https://edx-wiki.atlassian.net/browse/MCKIN-7023)

**Discussions**: [WL-230](https://openedx.atlassian.net/browse/WL-230), [YONK-879](https://openedx.atlassian.net/browse/YONK-879?focusedCommentId=307771&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-307771)

**Dependencies**:

* https://github.com/edx/xblock-utils/pull/48

**Screenshots**: 

**Before** these changes, the only text in Image Explorer HTML templates that would appear translated was the text that happened to be translated in edx-platform.
![before](https://user-images.githubusercontent.com/7556571/37281162-06e73d34-2640-11e8-9696-6ac20564b282.png)

**After** this change, Image Explorer template translations like [this one](https://github.com/edx-solutions/xblock-image-explorer/blob/master/image_explorer/templates/html/image_explorer_edit.html#L11) appear in Studio and LMS:
![after](https://user-images.githubusercontent.com/7556571/37281181-10e275c4-2640-11e8-9152-bbc8c2d7e7dd.png)

**Sandbox URL**:  sandbox is being provisioned.

* LMS: https://pr17670.sandbox.opencraft.hosting/
* Studio: https://studio-pr17670.sandbox.opencraft.hosting/

**Merge deadline**: None

**Testing instructions**:

1. Ensure that this xblock is installed (it's not included by default).
1. In Studio, create a course and add `"image-explorer"` to the Advanced Settings > Advanced Module List.  Add an Image Explorer unit, e.g. [Sandbox Image Explorer](https://studio-pr17670.sandbox.opencraft.hosting/container/block-v1:OpenCraft+IEx+2018_1+type@vertical+block@b04e746dee844037af04c880e2e495d2?action=new#) course.
1. Visit the Studio URL with `/update_lang` appended, and submit `eo` as your selected Language Code.
1. Edit the Image Explorer unit, and note that [`trans`](https://github.com/edx-solutions/xblock-image-explorer/blob/master/image_explorer/templates/html/image_explorer_edit.html#L11) template tags are respected, and their strings appear translated.

See the [updated README and run_test.py](https://github.com/edx-solutions/xblock-image-explorer/pull/37/commits/b3e24fc67dc555ddbd746bf94bf71adeab0b6481) for details on running the automated tests.

**Reviewers**
- [ ] @mtyaka 
- [ ] edx-solutions reviewer[s] TBD