### PR TITLE
Large Backgrounds fix

### DIFF
--- a/image_explorer/public/css/image_explorer.css
+++ b/image_explorer/public/css/image_explorer.css
@@ -6,6 +6,7 @@
 .image-explorer-wrapper {
     position: relative;
     display: inline-block;
+    max-width: 100%;
 }
 
 .image-explorer-wrapper img{

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-image-explorer',
-    version='0.7.0',
+    version='0.8.0',
     description='XBlock - Image Explorer',
     packages=['image_explorer'],
     install_requires=[


### PR DESCRIPTION
- Fixed large background image on Internet Explorer 
- Version bum from 0.7.0 to 0.8.0

**Steps to produce:**

- Use a large ( >780px ) background image in Internet Explorer
- Image should not flow outside the section

Ticket: [MCKIN-7429](https://edx-wiki.atlassian.net/browse/MCKIN-7429)

@bradenmacdonald 