### PR TITLE
Added the Ooyala video element

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ The `<youtube>` element offers a convenient way of placing an embedded
 YouTube video into a tooltip. The required attributes are `video_id`,
 `width`, and `height`.
 
+#### The Ooyala element
+
+The `<ooyala>` element offers a convenient way of placing an embedded
+Ooyala video into a tooltip. The required attributes are `video_id`,
+`width`, and `height`.
+
 API for native mobile frontends
 -------------------------------
 **Retrieve fixed data for all Image Explorer XBlocks in a course:**

--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -105,6 +105,7 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
         hotspots = self._get_hotspots(xmltree)
         background = self._get_background(xmltree)
         has_youtube = False
+        has_ooyala = False
 
         for hotspot in hotspots:
             width = 'width:{0}px'.format(hotspot.feedback.width) if hotspot.feedback.width else 'width:300px'
@@ -117,6 +118,9 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
             hotspot.reveal_style = 'style="{0};{1};{2}"'.format(width, height, max_height)
             if hotspot.feedback.youtube:
                 has_youtube = True
+
+            if hotspot.feedback.ooyala:
+                has_ooyala = True
 
         context = {
             'title': self.display_name,
@@ -132,6 +136,10 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/image_explorer.js'))
         if has_youtube:
             fragment.add_javascript_url('https://www.youtube.com/iframe_api')
+
+        if has_ooyala:
+            fragment.add_javascript_url('https://player.ooyala.com/v3/635104fd644c4170ae227af2de27deab?platform=html5-priority')
+            fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/ooyala_player.js'))
 
         fragment.initialize_js('ImageExplorerBlock')
 
@@ -318,6 +326,15 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
                 feedback.youtube.video_id = youtube_element.get('video_id')
                 feedback.youtube.width = youtube_element.get('width')
                 feedback.youtube.height = youtube_element.get('height')
+
+            feedback.ooyala = None
+            ooyala_element = feedback_element.find('ooyala')
+            if ooyala_element is not None:
+                feedback.type = 'ooyala'
+                feedback.ooyala = AttrDict()
+                feedback.ooyala.video_id = ooyala_element.get('video_id')
+                feedback.ooyala.width = ooyala_element.get('width')
+                feedback.ooyala.height = ooyala_element.get('height')
 
             hotspot = AttrDict()
             hotspot.item_id = hotspot_element.get('item-id')

--- a/image_explorer/public/js/ooyala_player.js
+++ b/image_explorer/public/js/ooyala_player.js
@@ -1,0 +1,8 @@
+$(function(){
+    $('#ooyalaplayer_2').closest('.image-explorer-hotspot').on('feedback:open', function (evt) {
+        var video_id = $('#ooyalaplayer_2').data("video-id")
+        OO.Player.create('ooyalaplayer_2', video_id);
+    }).on('feedback:close', function (evt) {
+        OO.Player.create('ooyalaplayer_2').pause();
+    });
+});

--- a/image_explorer/templates/html/image_explorer.html
+++ b/image_explorer/templates/html/image_explorer.html
@@ -28,6 +28,10 @@
                                 <iframe id="{{hotspot.feedback.youtube.id}}" class="youtube-player" type="text/html" width="{{hotspot.feedback.youtube.width}}" height="{{hotspot.feedback.youtube.height}}" src="https://www.youtube.com/embed/{{hotspot.feedback.youtube.video_id}}?enablejsapi=1" frameborder="0"></iframe>
                             </div>
                         {% endif %}
+                        {% if hotspot.feedback.ooyala %}
+                            <div id="ooyalaplayer_2" style="width: {{hotspot.feedback.ooyala.width}}px; height: {{hotspot.feedback.ooyala.height}}px;" data-video-id="{{hotspot.feedback.ooyala.video_id}}">
+                            </div>
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-image-explorer',
-    version='0.8.0',
+    version='0.9.0',
     description='XBlock - Image Explorer',
     packages=['image_explorer'],
     install_requires=[


### PR DESCRIPTION
This PR adds native support for Ooyala videos. A new <ooyala> element has been added very similar to the <youtube> element for displaying videos in hotspot tooltips.

**JIRA tickets**: OSPR-2388

**Sandbox**: [https://pr17986.sandbox.opencraft.hosting]()

**Screenshots**: 
![screen shot 2018-05-07 at 10 01 12 am](https://user-images.githubusercontent.com/9654006/39685688-c4904286-51dd-11e8-8dcc-6154486af6eb.png)

**Merge deadline**: 7th May 2018

**Testing instructions**:
Add the following xml definition for the Image Explorer:
```
<image_explorer schema_version='2'>
    <background src="//cdn.macrumors.com/article-new/2014/04/steve-jobs-iphone.jpg" />
    <description><p>Enjoy using the Image Explorer. Click on the iphone!</p></description>
    <hotspots>
        <hotspot x='65%' y='52%' item-id="hotspotB">
            <feedback width='370' height='270'>
                <header><p>Steve Jobs showing the iPhone</p></header>
                <ooyala video_id='hiZ3lpeTplH2jtdlbzGNfTmmb0pW5zlW' width='335' height='188' />
            </feedback>
        </hotspot>
    </hotspots>
</image_explorer>
![screen shot 2018-05-07 at 10 01 12 am](https://user-images.githubusercontent.com/9654006/39685667-a166f6c4-51dd-11e8-8bc3-cc091d4f640a.png)
```

Testing instructions for API endpoint:
https://github.com/edx-solutions/xblock-image-explorer#api-for-native-mobile-frontends

GET https://<lms_server_url>/api/courses/v1/blocks/?course_id=<course_id>&username=<username>&depth=all&requested_fields=student_view_data

e.g.
http://localhost:18000/api/courses/v1/blocks/?course_id=course-v1:afzalx%2bcs101%2b2018_T1&username=afzalwali&depth=all&requested_fields=student_view_data&student_view_data=image-explorer

Should return a JSON response. The feedback dictionary should indicate the "type" as "ooyala". Moreover, there should be a key ooyala containing the video_id, width and height as entered in the ooyala element.

e.g.:

```
{
  "feedback": {
    "body": null,
    "width": "440",
    "youtube": null,
    "max_height": null,
    "height": "400",
    "header": "<p>The CEO of Vodafone explains his amazing first meeting with Steve Jobs showing the first iPhone<\/p>",
    "ooyala": {
      "width": "400",
      "video_id": "hiZ3lpeTplH2jtdlbzGNfTmmb0pW5zlW",
      "height": "300"
    },
    "type": "ooyala",
    "side": "auto"
  }
}
```

**Author notes and concerns**:
If both the youtube and the ooyala elements are present, this would be an anomaly, but it will display both the youtube as well as the ooyala videos in the popup. The API endpoint would mark the feedback type as ooyala, but list both the youtube and the ooyala keys in the feedback dictionary.

**Reviewers**
- [x] (@tomaszgy )
- [ ] edX reviewer[s] TBD
