### PR TITLE
MCKIN-8752: Make it complete on submission instead of on view.

### DIFF
--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -31,6 +31,7 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
     """
 
     has_score = True
+    max_score = 1.0
     completion_mode = XBlockCompletionMode.COMPLETABLE
 
     display_name = String(

--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -12,6 +12,7 @@ from parsel import Selector
 
 from django.conf import settings
 
+from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
 from xblock.fragment import Fragment
 from xblock.fields import List, Scope, String, Boolean
@@ -28,6 +29,10 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
     """
     XBlock that renders an image with tooltips
     """
+
+    has_score = True
+    completion_mode = XBlockCompletionMode.COMPLETABLE
+
     display_name = String(
         display_name=_("Display Name"),
         help=_("This name appears in the horizontal navigation at the top of the page."),

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,11 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-image-explorer',
-    version='1.0.1',
+    version='1.1.0',
     description='XBlock - Image Explorer',
     packages=['image_explorer'],
     install_requires=[
-        'XBlock',
+        'XBlock>=1.2',
     ],
     entry_points={
         'xblock.v1': 'image-explorer = image_explorer:ImageExplorerBlock',


### PR DESCRIPTION
Update image-explorer to complete when emitting a `grade` event, instead of on view

**JIRA tickets**: Fixes part of MCKIN-8752

**Discussions**: N/A

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: ASAP

**Testing instructions**:

1. Create an image explorer block.
2. Visit it.
3. Verify that no BlockCompletion objects are created.
4. Submit a response for grading.
5. Verify that a BlockCompletion object is created.

**Author notes and concerns**:

N/A

**Reviewers**
- [x] @viadanna 

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```