### PR TITLE
BB-1025 Add visited hotspots styling

### DIFF
--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -373,7 +373,9 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
             if not hotspot.y.endswith('%'):
                 hotspot.y += 'px'  # px is deprecated as it is not responsive
 
-            hotspot.visited = True
+            hotspot.visited = False
+            if hotspot.item_id in self.opened_hotspots:
+                hotspot.visited = True
 
             hotspots.append(hotspot)
 

--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -373,7 +373,7 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
             if not hotspot.y.endswith('%'):
                 hotspot.y += 'px'  # px is deprecated as it is not responsive
 
-            hotspot.visited = hotspot.item_id in self.opened_hotspots:
+            hotspot.visited = hotspot.item_id in self.opened_hotspots
 
             hotspots.append(hotspot)
 

--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -373,6 +373,8 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
             if not hotspot.y.endswith('%'):
                 hotspot.y += 'px'  # px is deprecated as it is not responsive
 
+            hotspot.visited = True
+
             hotspots.append(hotspot)
 
         return hotspots

--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -373,9 +373,7 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
             if not hotspot.y.endswith('%'):
                 hotspot.y += 'px'  # px is deprecated as it is not responsive
 
-            hotspot.visited = False
-            if hotspot.item_id in self.opened_hotspots:
-                hotspot.visited = True
+            hotspot.visited = hotspot.item_id in self.opened_hotspots:
 
             hotspots.append(hotspot)
 

--- a/image_explorer/public/css/image_explorer.css
+++ b/image_explorer/public/css/image_explorer.css
@@ -64,7 +64,7 @@ div.image-explorer-hotspot a{
     text-decoration: underline;
 }
 
-.image-explorer-wrapper div.image-explorer-hotspot:hover {
+.image-explorer-wrapper div.image-explorer-hotspot:hover, .image-explorer-wrapper.visited {
     background-position: 0 -43px
 }
 

--- a/image_explorer/public/css/image_explorer.css
+++ b/image_explorer/public/css/image_explorer.css
@@ -64,7 +64,8 @@ div.image-explorer-hotspot a{
     text-decoration: underline;
 }
 
-.image-explorer-wrapper div.image-explorer-hotspot:hover, .image-explorer-wrapper.visited {
+.image-explorer-wrapper div.image-explorer-hotspot:hover,
+.image-explorer-wrapper div.image-explorer-hotspot.visited {
     background-position: 0 -43px
 }
 

--- a/image_explorer/templates/html/image_explorer.html
+++ b/image_explorer/templates/html/image_explorer.html
@@ -9,7 +9,9 @@
     <div class="image-explorer-wrapper">
         <img src="{{background.src}}" class="image-explorer-background" />
         {% for hotspot in hotspots %}
-        <div class="image-explorer-hotspot {% if hotspot_coordinates_centered %}centered{% endif %}" style="position: absolute; top: {{hotspot.y}}; left: {{hotspot.x}};" data-item-id="{{hotspot.item_id}}">
+        <div class="image-explorer-hotspot {% if hotspot_coordinates_centered %}centered{% endif %}{% if hotspot.viiste %}visited{% endif %}"
+             style="position: absolute; top: {{hotspot.y}}; left: {{hotspot.x}};"
+             data-item-id="{{hotspot.item_id}}">
                 <div class="image-explorer-hotspot-reveal" {{hotspot.reveal_style}} data-side="{{ hotspot.feedback.side }}">
                     <div class="image-explorer-close-reveal">&#xf057;</div>
                     <div class="image-explorer-hotspot-content-wrapper">

--- a/image_explorer/templates/html/image_explorer.html
+++ b/image_explorer/templates/html/image_explorer.html
@@ -9,7 +9,7 @@
     <div class="image-explorer-wrapper">
         <img src="{{background.src}}" class="image-explorer-background" />
         {% for hotspot in hotspots %}
-        <div class="image-explorer-hotspot {% if hotspot_coordinates_centered %}centered{% endif %}{% if hotspot.viiste %}visited{% endif %}"
+        <div class="image-explorer-hotspot {% if hotspot_coordinates_centered %}centered{% endif %}{% if hotspot.visited %} visited {% endif %}"
              style="position: absolute; top: {{hotspot.y}}; left: {{hotspot.x}};"
              data-item-id="{{hotspot.item_id}}">
                 <div class="image-explorer-hotspot-reveal" {{hotspot.reveal_style}} data-side="{{ hotspot.feedback.side }}">

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-image-explorer',
-    version='1.1.2',
+    version='1.1.3',
     description='XBlock - Image Explorer',
     packages=['image_explorer'],
     install_requires=[

--- a/tests/integration/test_image_explorer.py
+++ b/tests/integration/test_image_explorer.py
@@ -47,6 +47,8 @@ class TestImageExplorer(SeleniumXBlockTest):
         self.assertIn("Below are some of the highlights:", block.hotspotA.content.text)
         self.assertIn("Once there was a police car up here", block.hotspotA.content.text)
         self.assertIn("Also there was a Fire Truck put up there", block.hotspotA.content.text)
+        self.assertIn('visited', block.hotspotA.get_attribute("class"))
+        self.assertNotIn('visited', block.hotspotB.get_attribute("class"))
 
     def assert_only_hotspotB_revealed(self, block):
         hs = self.hotspots(block)
@@ -57,6 +59,8 @@ class TestImageExplorer(SeleniumXBlockTest):
 
         self.assertIn("Watch the Red Line subway go around the dome", block.hotspotB.content.text)
         self.assertTrue(block.hotspotB.find_element_by_css_selector(".image-explorer-hotspot-reveal-youtube"))
+        self.assertNotIn('visited', block.hotspotA.get_attribute("class"))
+        self.assertIn('visited', block.hotspotB.get_attribute("class"))
 
     def test_simple_scenario(self):
         self.set_scenario_xml('<image-explorer/>')
@@ -65,6 +69,8 @@ class TestImageExplorer(SeleniumXBlockTest):
 
         self.assert_in_default_state(block)
 
+        self.assertNotIn('visited', block.hotspotA.get_attribute("class"))
+        self.assertNotIn('visited' in block.hotspotB.get_attribute("class"))
         block.hotspotA.click()
         self.assert_only_hotspotA_revealed(block)
 

--- a/tests/integration/test_image_explorer.py
+++ b/tests/integration/test_image_explorer.py
@@ -48,7 +48,6 @@ class TestImageExplorer(SeleniumXBlockTest):
         self.assertIn("Once there was a police car up here", block.hotspotA.content.text)
         self.assertIn("Also there was a Fire Truck put up there", block.hotspotA.content.text)
         self.assertIn('visited', block.hotspotA.get_attribute("class"))
-        self.assertNotIn('visited', block.hotspotB.get_attribute("class"))
 
     def assert_only_hotspotB_revealed(self, block):
         hs = self.hotspots(block)
@@ -59,7 +58,6 @@ class TestImageExplorer(SeleniumXBlockTest):
 
         self.assertIn("Watch the Red Line subway go around the dome", block.hotspotB.content.text)
         self.assertTrue(block.hotspotB.find_element_by_css_selector(".image-explorer-hotspot-reveal-youtube"))
-        self.assertNotIn('visited', block.hotspotA.get_attribute("class"))
         self.assertIn('visited', block.hotspotB.get_attribute("class"))
 
     def test_simple_scenario(self):
@@ -70,7 +68,7 @@ class TestImageExplorer(SeleniumXBlockTest):
         self.assert_in_default_state(block)
 
         self.assertNotIn('visited', block.hotspotA.get_attribute("class"))
-        self.assertNotIn('visited' in block.hotspotB.get_attribute("class"))
+        self.assertNotIn('visited', block.hotspotB.get_attribute("class"))
         block.hotspotA.click()
         self.assert_only_hotspotA_revealed(block)
 

--- a/tests/unit/test_image_explorer.py
+++ b/tests/unit/test_image_explorer.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from mock import patch
 from lxml import etree
 
 from parsel import Selector
@@ -142,6 +142,6 @@ class TestImageExplorerBlock(unittest.TestCase):
             DictFieldData(image_explorer_data),
             None
         )
-        hotspots = image_explorer_data._get_hotspots(xmltree=etree.fromstring(self.image_explorer_xml))
+        hotspots = image_explorer_block_schema2._get_hotspots(xmltree=etree.fromstring(self.image_explorer_xml))
         self.assertEqual(len(hotspots), 1)
         self.assertTrue(hotspots[0].visited)

--- a/tests/unit/test_image_explorer.py
+++ b/tests/unit/test_image_explorer.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 from lxml import etree
 
 from parsel import Selector
@@ -129,3 +130,18 @@ class TestImageExplorerBlock(unittest.TestCase):
 
         # for schema version 2 hotspot coordinates are centered
         self.assertTrue(image_explorer_block_schema2.hotspot_coordinates_centered)
+
+    @patch('image_explorer.image_explorer.ImageExplorerBlock._inner_content')
+    def test__get_hotspots(self, mock__inner_content):
+        """
+        Test _get_hotspots return all hotspots.
+        """
+        image_explorer_data = {'data': self.image_explorer_xml_version2}
+        image_explorer_block_schema2 = ImageExplorerBlock(
+            self.runtime,
+            DictFieldData(image_explorer_data),
+            None
+        )
+        hotspots = image_explorer_data._get_hotspots(xmltree=etree.fromstring(self.image_explorer_xml))
+        self.assertEqual(len(hotspots), 1)
+        self.assertTrue(hotspots[0].visited)

--- a/tests/unit/test_image_explorer.py
+++ b/tests/unit/test_image_explorer.py
@@ -144,4 +144,8 @@ class TestImageExplorerBlock(unittest.TestCase):
         )
         hotspots = image_explorer_block_schema2._get_hotspots(xmltree=etree.fromstring(self.image_explorer_xml))
         self.assertEqual(len(hotspots), 1)
+        self.assertFalse(hotspots[0].visited)
+        image_explorer_block_schema2.opened_hotspots.append('hotspotA')
+        hotspots = image_explorer_block_schema2._get_hotspots(xmltree=etree.fromstring(self.image_explorer_xml))
+        self.assertEqual(len(hotspots), 1)
         self.assertTrue(hotspots[0].visited)


### PR DESCRIPTION
This PR adds a `visited` attribute to visited hotspots and adds a class in the HTML that will simulate a "hover" state. The result is visually rendering visited hotspots as if they were in the "hover" state.

**JIRA tickets**:

**Discussions**: 

**Dependencies**: None

**Screenshots**: 
![Screen Shot 2019-03-18 at 12 02 45 PM](https://user-images.githubusercontent.com/4007280/54548380-cb296600-4975-11e9-884b-55d521ee8c90.png)
In the screenshot the leftmost and uppermost hot-spots has been visited.

**Sandbox URL**: 

**Merge deadline**: "None" if there's no rush, "ASAP" if it's critical, or provide a specific date if there is one.

**Testing instructions**:

1. Checkout this branch
2. Visit a few image hotspots.

**Author notes and concerns**:

**Reviewers**
- [ ] @xitij2000 