### PR TITLE
[MCKIN-10542] Fix triggers on mobile

### DIFF
--- a/image_explorer/public/css/image_explorer.css
+++ b/image_explorer/public/css/image_explorer.css
@@ -66,7 +66,7 @@ div.image-explorer-hotspot a{
 
 .image-explorer-wrapper div.image-explorer-hotspot:hover,
 .image-explorer-wrapper div.image-explorer-hotspot.visited {
-    background-position: 0 -43px
+    background-position: 0 100%;
 }
 
 div.image-explorer-hotspot .image-explorer-hotspot-reveal .image-explorer-hotspot-reveal-header p {
@@ -121,7 +121,7 @@ div.image-explorer-hotspot .image-explorer-hotspot-reveal .image-explorer-hotspo
     .image-explorer-hotspot-reveal{
         right: 0;
         left: 0;
-        top: 143px;
+        top: 185px;
         bottom: 10vh;
         width: auto !important;
         height: auto !important;

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-image-explorer',
-    version='1.1.3',
+    version='1.1.4',
     description='XBlock - Image Explorer',
     packages=['image_explorer'],
     install_requires=[


### PR DESCRIPTION
This fixes image triggers and `reveal` alignment to prevent it from being hidden under navigation bar.

## Testing instructions:
1. Checkout this branch.
1. Create course with Image Explorer block.
1. Change width to anything between `270px` and `767px`.
1. Check that `visited` triggers are still visible and the `reveal` has its `close` button visible.