### PR TITLE
BB-1073: Set up CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,50 @@
+version: 2
+jobs:
+  test:
+    docker:
+      - image: circleci/python:2.7.16-browsers
+    steps:
+      - checkout
+      - run:
+          name: Install Dependencies
+          command: |
+            mkdir -p ./venv
+            virtualenv ./venv
+            . venv/bin/activate
+            pip install tox
+      - run:
+          name: Run unit tests
+          command: |
+            . venv/bin/activate
+            tox -e unit
+          when: always
+      - run:
+          name: Run integration tests
+          command: |
+            . venv/bin/activate
+            tox -e integration
+          when: always
+  quality:
+    docker:
+      - image: circleci/python:2.7.16
+    steps:
+      - checkout
+      - run:
+          name: Install Dependencies
+          command: |
+            mkdir -p ./venv
+            virtualenv ./venv
+            . venv/bin/activate
+            pip install tox pylint
+      - run:
+          name: Run integration tests
+          command: |
+            . venv/bin/activate
+            tox -e quality
+          when: always
+workflows:
+  version: 2
+  build:
+    jobs:
+      - test
+      - quality

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ xblock_image_explorer.egg-info
 *~
 var/workbench.log*
 geckodriver.log
+.tox

--- a/README.md
+++ b/README.md
@@ -35,25 +35,20 @@ advanced settings.
 Testing
 -------
 
-Make sure you have a python virtual environment with `xblock-sdk` version `0.1.5` or higher:
+Make sure you have firefox and geckodriver installed and added to your `PATH`,
+then, follow these instructions:
 
-```bash
-pip install -e git://github.com/edx/xblock-sdk.git#egg=xblock-sdk
-cd $VIRTUAL_ENV/src/xblock-sdk/ && make install && cd -
-pip install -r requirements.txt
+1. Create a virtualenv and enable it.
+
+2. Install tox with `pip install tox`
+
+3. Run `tox` to run all tests.
+
+You can also run separate test environments like this:
 ```
-
-To run the unit tests, run:
-
-```bash
-python run_tests.py tests/unit
-```
-
-To run the integration tests, you'll need [`geckodriver`](https://github.com/mozilla/geckodriver) and `xvfb` installed.
-
-```bash
-export DISPLAY=:99
-xvfb-run python run_tests.py tests/integration
+tox -e unit  # Run only unit tests
+tox -e integration  # Integration tests
+tox -e quality  # pylint
 ```
 
 Usage

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,27 @@
+[REPORTS]
+reports=no
+
+[FORMAT]
+max-line-length=120
+max-module-lines=1500
+
+[MESSAGES CONTROL]
+disable=
+    locally-disabled,
+    too-many-ancestors,
+    too-many-instance-attributes,
+    too-few-public-methods,
+    too-many-public-methods,
+    unused-argument
+
+[SIMILARITIES]
+min-similarity-lines=4
+
+[OPTIONS]
+good-names=_,__,logger,loader
+method-rgx=_?[a-z_][a-z0-9_]{2,40}$
+function-rgx=_?[a-z_][a-z0-9_]{2,40}$
+method-name-hint=_?[a-z_][a-z0-9_]{2,40}$
+function-name-hint=_?[a-z_][a-z0-9_]{2,40}$
+
+extension-pkg-whitelist=lxml

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+envlist = unit,integration,quality
+
+[testenv]
+whitelist_externals =
+  make
+commands_pre =
+  pip install -e 'git://github.com/edx/xblock-sdk.git#egg=xblock-sdk'
+  make -C {envdir}/src/xblock-sdk/ install
+  pip install -r requirements.txt
+
+[testenv:unit]
+commands =
+  python run_tests.py tests/unit
+
+[testenv:integration]
+passenv = *
+commands =
+  python run_tests.py tests/integration
+
+[testenv:quality]
+commands =
+  pylint image_explorer


### PR DESCRIPTION
This PR sets up CI tests for this repo. The checks ran with these checks are:
1. Unit tests
2. Code quality tests

Until we get a code code quality, we should leave only the **unit test** as required for merging.

**Testing instructions:**
1. Check the tox and Travis configuration files.
2. Test locally with `tox`:
```
pip install tox
tox
```
3. Check if the CI `tests` container is green.

**Reviewers:**
- [ ] @xitij2000 

