### PR TITLE
MCKIN-12183 AF#71-Image_Explorer-Ensure that dialogs can be closed via the keyboard

### DIFF
--- a/image_explorer/public/js/image_explorer.js
+++ b/image_explorer/public/js/image_explorer.js
@@ -118,6 +118,18 @@ function ImageExplorerBlock(runtime, element) {
       }
     });
 
+    $(document).on('keyup', function(eventObj) {
+      if (!active_feedback)
+        return;
+      var target = $(eventObj.target);
+      var close_btn = ".image-explorer-close-reveal";
+      if (target.is(close_btn) && eventObj.keyCode === 13) {
+        close_feedback();
+        eventObj.preventDefault();
+        eventObj.stopPropagation();
+      }
+    });
+
     publish_event({
         event_type:'xblock.image-explorer.loaded'
     });

--- a/image_explorer/templates/html/image_explorer.html
+++ b/image_explorer/templates/html/image_explorer.html
@@ -13,7 +13,6 @@
              style="position: absolute; top: {{hotspot.y}}; left: {{hotspot.x}};"
              data-item-id="{{hotspot.item_id}}">
                 <div class="image-explorer-hotspot-reveal" {{hotspot.reveal_style}} data-side="{{ hotspot.feedback.side }}">
-                    <div class="image-explorer-close-reveal">&#xf057;</div>
                     <div class="image-explorer-hotspot-content-wrapper">
                         {% if hotspot.feedback.header %}
                             <span class="image-explorer-hotspot-reveal-header">
@@ -35,6 +34,7 @@
                             </div>
                         {% endif %}
                     </div>
+                    <div class="image-explorer-close-reveal" tabindex="0">&#xf057;</div>
                 </div>
             </div>
         {% endfor %}

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-image-explorer',
-    version='1.1.5',
+    version='1.1.6',
     description='XBlock - Image Explorer',
     packages=['image_explorer'],
     install_requires=[


### PR DESCRIPTION
MCKIN-12183 AF#71-Image_Explorer-Ensure that dialogs can be closed via the keyboard

Developers must ensure that the element used to close the dialog is reachable via the keyboard. Typically this would be through the use of the tab or shift+tab key.  Developers should ensure that the close link/button can be activated via the keyboard via the ENTER key. 