### PR TITLE
MCKIN-12179 Image_Explorer hotspot are key board accessible now

### DIFF
--- a/image_explorer/public/css/image_explorer.css
+++ b/image_explorer/public/css/image_explorer.css
@@ -41,11 +41,12 @@
 }
 
 
-.image-explorer-wrapper div.image-explorer-hotspot {
+.image-explorer-wrapper button.image-explorer-hotspot {
     background: url("../images/hotspot-sprite.png") no-repeat scroll 0 0 rgba(0, 0, 0, 0);
     width: 41px;
     height: 41px;
     display: block;
+    border: 0;
     text-decoration: none;
     -webkit-transition: all 0.0s linear 0s;
     -moz-transition: all 0.0s linear 0s;
@@ -58,18 +59,18 @@
     margin-top: -20.5px;
 }
 
-div.image-explorer-hotspot a{
+button.image-explorer-hotspot a{
     color: #FFFFFF;
     font-weight: bold;
     text-decoration: underline;
 }
 
-.image-explorer-wrapper div.image-explorer-hotspot:hover,
-.image-explorer-wrapper div.image-explorer-hotspot.visited {
+.image-explorer-wrapper button.image-explorer-hotspot:hover,
+.image-explorer-wrapper button.image-explorer-hotspot.visited {
     background-position: 0 100%;
 }
 
-div.image-explorer-hotspot .image-explorer-hotspot-reveal .image-explorer-hotspot-reveal-header p {
+button.image-explorer-hotspot .image-explorer-hotspot-reveal .image-explorer-hotspot-reveal-header p {
     margin: 10px 0 10px 20px;
 }
 
@@ -82,7 +83,7 @@ div.image-explorer-hotspot .image-explorer-hotspot-reveal .image-explorer-hotspo
     list-style-type: disc;
 }
 
-div.image-explorer-hotspot .image-explorer-hotspot-reveal .image-explorer-hotspot-reveal-body ul li {
+button.image-explorer-hotspot .image-explorer-hotspot-reveal .image-explorer-hotspot-reveal-body ul li {
     margin: 0 0 24px 17px;
 }
 
@@ -110,12 +111,12 @@ div.image-explorer-hotspot .image-explorer-hotspot-reveal .image-explorer-hotspo
 }
 
 @media only screen and (max-width: 767px){
-    .image-explorer-wrapper div.image-explorer-hotspot{
+    .image-explorer-wrapper button.image-explorer-hotspot{
         background-size: 100%;
         width: 16px;
         height: 16px;
     }
-    .image-explorer-wrapper div.image-explorer-hotspot:hover{
+    .image-explorer-wrapper button.image-explorer-hotspot:hover{
         background-position: 0 -17px;
     }
     .image-explorer-hotspot-reveal{

--- a/image_explorer/templates/html/image_explorer.html
+++ b/image_explorer/templates/html/image_explorer.html
@@ -9,7 +9,7 @@
     <div class="image-explorer-wrapper">
         <img src="{{background.src}}" class="image-explorer-background" />
         {% for hotspot in hotspots %}
-        <div class="image-explorer-hotspot {% if hotspot_coordinates_centered %}centered{% endif %}{% if hotspot.visited %} visited {% endif %}"
+        <button class="image-explorer-hotspot {% if hotspot_coordinates_centered %}centered{% endif %}{% if hotspot.visited %} visited {% endif %}"
              style="position: absolute; top: {{hotspot.y}}; left: {{hotspot.x}};"
              data-item-id="{{hotspot.item_id}}">
                 <div class="image-explorer-hotspot-reveal" {{hotspot.reveal_style}} data-side="{{ hotspot.feedback.side }}">
@@ -36,7 +36,7 @@
                     </div>
                     <div class="image-explorer-close-reveal" tabindex="0">&#xf057;</div>
                 </div>
-            </div>
+            </button>
         {% endfor %}
     </div>
 </div>

--- a/image_explorer/templates/html/image_explorer.html
+++ b/image_explorer/templates/html/image_explorer.html
@@ -13,6 +13,7 @@
              style="position: absolute; top: {{hotspot.y}}; left: {{hotspot.x}};"
              data-item-id="{{hotspot.item_id}}">
                 <div class="image-explorer-hotspot-reveal" {{hotspot.reveal_style}} data-side="{{ hotspot.feedback.side }}">
+                    <div class="image-explorer-close-reveal" tabindex="0">&#xf057;</div>
                     <div class="image-explorer-hotspot-content-wrapper">
                         {% if hotspot.feedback.header %}
                             <span class="image-explorer-hotspot-reveal-header">
@@ -34,7 +35,6 @@
                             </div>
                         {% endif %}
                     </div>
-                    <div class="image-explorer-close-reveal" tabindex="0">&#xf057;</div>
                 </div>
             </button>
         {% endfor %}

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-image-explorer',
-    version='1.1.6',
+    version='1.1.7',
     description='XBlock - Image Explorer',
     packages=['image_explorer'],
     install_requires=[


### PR DESCRIPTION
Image explorer hostspot was not keyboard accessible in the form of div's. Now it has been changed to button to meet accessibility criteria keeping in view of accessibility recommendations.