### PR TITLE
MCKIN-12728 - Brigthcove video playback support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ The `<ooyala>` element offers a convenient way of placing an embedded
 Ooyala video into a tooltip. The required attributes are `video_id`,
 `width`, and `height`.
 
+#### The Brightcove element
+
+The `<brightcove>` element offers a convenient way of placing an embedded
+Brightcove video into a tooltip. The required attributes are `video_id`,
+`account_id`, `width`, and `height`.
+e.g;
+```
+<brightcove video_id="6110618169001" account_id="6057949416001" width="320px" height="180px" />
+```
+
 API for native mobile frontends
 -------------------------------
 **Retrieve fixed data for all Image Explorer XBlocks in a course:**

--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -409,6 +409,17 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
                 feedback.ooyala.width = ooyala_element.get('width')
                 feedback.ooyala.height = ooyala_element.get('height')
 
+            # BC element could be anywhere in the hotspot
+            bcove_element = hotspot_element.find(".//brightcove")
+            if bcove_element is not None:
+                feedback.type = 'brightcove'
+                feedback.bcove = AttrDict()
+                feedback.bcove.id = 'bcove-{}'.format(uuid.uuid4().hex)
+                feedback.bcove.video_id = bcove_element.get('video_id')
+                feedback.bcove.account_id = bcove_element.get('account_id')
+                feedback.bcove.width = bcove_element.get('width')
+                feedback.bcove.height = bcove_element.get('height')
+
             hotspot = AttrDict()
             hotspot.item_id = hotspot_element.get('item-id')
             if hotspot.item_id is None:

--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -184,9 +184,9 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
             fragment.add_javascript_url('https://www.youtube.com/iframe_api')
 
         if has_ooyala:
-            # fragment.add_javascript_url(
-            #     '//player.ooyala.com/core/10efd95b66124001b415aa2a4bee29c8?plugins=main,bm'
-            # )
+            fragment.add_javascript_url(
+                '//player.ooyala.com/core/10efd95b66124001b415aa2a4bee29c8?plugins=main,bm'
+            )
             fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/ooyala_player.js'))
 
         fragment.initialize_js('ImageExplorerBlock')

--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -184,9 +184,9 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
             fragment.add_javascript_url('https://www.youtube.com/iframe_api')
 
         if has_ooyala:
-            fragment.add_javascript_url(
-                'https://player.ooyala.com/v3/635104fd644c4170ae227af2de27deab?platform=html5-priority'
-            )
+            # fragment.add_javascript_url(
+            #     '//player.ooyala.com/core/10efd95b66124001b415aa2a4bee29c8?plugins=main,bm'
+            # )
             fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/ooyala_player.js'))
 
         fragment.initialize_js('ImageExplorerBlock')
@@ -390,35 +390,7 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
                 feedback.type = 'text'
                 feedback.body = self._inner_content(body_element, absolute_urls)
 
-            feedback.youtube = None
-            youtube_element = feedback_element.find('youtube')
-            if youtube_element is not None:
-                feedback.type = 'youtube'
-                feedback.youtube = AttrDict()
-                feedback.youtube.id = 'youtube-{}'.format(uuid.uuid4().hex)
-                feedback.youtube.video_id = youtube_element.get('video_id')
-                feedback.youtube.width = youtube_element.get('width')
-                feedback.youtube.height = youtube_element.get('height')
-
-            feedback.ooyala = None
-            ooyala_element = feedback_element.find('ooyala')
-            if ooyala_element is not None:
-                feedback.type = 'ooyala'
-                feedback.ooyala = AttrDict()
-                feedback.ooyala.video_id = ooyala_element.get('video_id')
-                feedback.ooyala.width = ooyala_element.get('width')
-                feedback.ooyala.height = ooyala_element.get('height')
-
-            # BC element could be anywhere in the hotspot
-            bcove_element = hotspot_element.find(".//brightcove")
-            if bcove_element is not None:
-                feedback.type = 'brightcove'
-                feedback.bcove = AttrDict()
-                feedback.bcove.id = 'bcove-{}'.format(uuid.uuid4().hex)
-                feedback.bcove.video_id = bcove_element.get('video_id')
-                feedback.bcove.account_id = bcove_element.get('account_id')
-                feedback.bcove.width = bcove_element.get('width')
-                feedback.bcove.height = bcove_element.get('height')
+            self._collect_video_elements(hotspot_element, feedback)
 
             hotspot = AttrDict()
             hotspot.item_id = hotspot_element.get('item-id')
@@ -439,6 +411,43 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
             hotspots.append(hotspot)
 
         return hotspots
+
+    @staticmethod
+    def _collect_video_elements(hotspot, feedback):
+        """
+        Parses and includes video elements contained in the hotspot
+        """
+        feedback_element = hotspot.find('feedback')
+
+        feedback.youtube = None
+        youtube_element = feedback_element.find('youtube')
+        if youtube_element is not None:
+            feedback.type = 'youtube'
+            feedback.youtube = AttrDict()
+            feedback.youtube.id = 'youtube-{}'.format(uuid.uuid4().hex)
+            feedback.youtube.video_id = youtube_element.get('video_id')
+            feedback.youtube.width = youtube_element.get('width')
+            feedback.youtube.height = youtube_element.get('height')
+
+        feedback.ooyala = None
+        ooyala_element = feedback_element.find('ooyala')
+        if ooyala_element is not None:
+            feedback.type = 'ooyala'
+            feedback.ooyala = AttrDict()
+            feedback.ooyala.id = 'oo-{}'.format(uuid.uuid4().hex)
+            feedback.ooyala.video_id = ooyala_element.get('video_id')
+            feedback.ooyala.width = ooyala_element.get('width')
+            feedback.ooyala.height = ooyala_element.get('height')
+
+        # BC element could be anywhere in the hotspot
+        bcove_element = hotspot.find(".//brightcove")
+        if bcove_element is not None:
+            feedback.bcove = AttrDict()
+            feedback.bcove.id = 'bcove-{}'.format(uuid.uuid4().hex)
+            feedback.bcove.video_id = bcove_element.get('video_id')
+            feedback.bcove.account_id = bcove_element.get('account_id')
+            feedback.bcove.width = bcove_element.get('width')
+            feedback.bcove.height = bcove_element.get('height')
 
     @staticmethod
     def workbench_scenarios():

--- a/image_explorer/public/js/ooyala_player.js
+++ b/image_explorer/public/js/ooyala_player.js
@@ -1,8 +1,6 @@
 $(function(){
-    $('#ooyalaplayer_2').closest('.image-explorer-hotspot').on('feedback:open', function (evt) {
-        var video_id = $('#ooyalaplayer_2').data("video-id")
-        OO.Player.create('ooyalaplayer_2', video_id);
-    }).on('feedback:close', function (evt) {
-        OO.Player.create('ooyalaplayer_2').pause();
+    // create Ooyala videos 
+    $('.ooyala-element').each(function(){
+        OO.Player.create(this.id, $(this).data('video-id')); 
     });
 });

--- a/image_explorer/templates/html/image_explorer.html
+++ b/image_explorer/templates/html/image_explorer.html
@@ -38,8 +38,7 @@
                             </div>
                         {% endif %}
                         {% if hotspot.feedback.ooyala %}
-                            <div id="ooyalaplayer_2" style="width: {{hotspot.feedback.ooyala.width}}px; height: {{hotspot.feedback.ooyala.height}}px;" data-video-id="{{hotspot.feedback.ooyala.video_id}}">
-                            </div>
+                            <div class="ooyala-element" id="{{hotspot.feedback.ooyala.id}}" style="width: {{hotspot.feedback.ooyala.width}}px; height: {{hotspot.feedback.ooyala.height}}px;" data-video-id="{{hotspot.feedback.ooyala.video_id}}"></div>
                         {% endif %}
                         {% if hotspot.feedback.bcove %}
                             <video-js

--- a/image_explorer/templates/html/image_explorer.html
+++ b/image_explorer/templates/html/image_explorer.html
@@ -41,6 +41,19 @@
                             <div id="ooyalaplayer_2" style="width: {{hotspot.feedback.ooyala.width}}px; height: {{hotspot.feedback.ooyala.height}}px;" data-video-id="{{hotspot.feedback.ooyala.video_id}}">
                             </div>
                         {% endif %}
+                        {% if hotspot.feedback.bcove %}
+                            <video-js
+                                id="{{hotspot.feedback.bcove.id}}"
+                                data-account="{{hotspot.feedback.bcove.account_id}}"
+                                data-player="default"
+                                data-embed="default"
+                                data-video-id="{{hotspot.feedback.bcove.video_id}}"
+                                controls=""
+                                playsinline=""
+                                style="width:{{hotspot.feedback.bcove.width}}; height:{{hotspot.feedback.bcove.height}}">
+                            </video-js>
+                            <script src="https://players.brightcove.net/{{hotspot.feedback.bcove.account_id}}/default_default/index.min.js"></script>
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-image-explorer',
-    version='1.1.9',
+    version='1.1.10',
     description='XBlock - Image Explorer',
     packages=['image_explorer'],
     install_requires=[


### PR DESCRIPTION
This PR adds native support for Brightcove videos playback and also does a bit of refactoring.

1. Brightcove video can now be added using `<brightcove>` element
``` 
<brightcove video_id="6110618169001" account_id="6057949416001" width="320px" height="180px" /> 
```
2. Videos (Youtube, Ooyala and Brightcove) are paused on closing the hotspot.
3. `createOoyalaVideos` method for playing Ooyala videos authored using embed to maintain backward compatibility. 