### PR TITLE
SE-3013 Added parsel library to the setup.py required dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     packages=['image_explorer'],
     install_requires=[
         'XBlock>=1.2',
+        'parsel>=1.2.0,<=1.3.0',
     ],
     entry_points={
         'xblock.v1': 'image-explorer = image_explorer:ImageExplorerBlock',


### PR DESCRIPTION
### Description
Added `parsel` requirements to package dependencies. Without this package, xblock-image-explorer is not installed properly. 

### Testing instructions:

1. Run instance and provide link to xblock-image-explorer
2. Get working instance with properly configures xblock-image-explorer

### Author notes and concerns:
Would be cool to setup xblock-image-explorer python package to include all required dependencies at setup.py (or even publish to pypi)

- [ ] @pkulkark  
