### PR TITLE
[SE-3173] Updates XBlock to Support Python 3 for Juniper Release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/python:2.7.16-browsers
+      - image: circleci/python:3.5-browsers
     steps:
       - checkout
       - run:
@@ -26,7 +26,7 @@ jobs:
           when: always
   quality:
     docker:
-      - image: circleci/python:2.7.16
+      - image: circleci/python:3.5
     steps:
       - checkout
       - run:
@@ -36,12 +36,6 @@ jobs:
             virtualenv ./venv
             . venv/bin/activate
             pip install tox pylint
-      - run:
-          name: Run quality tests
-          command: |
-            . venv/bin/activate
-            tox -e quality
-          when: always
       - run:
           name: Run python3 quality tests
           command: |

--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -354,7 +354,7 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
         Helper met
         """
         if tag is not None:
-            tag_content = u''.join(html.tostring(e) for e in tag)
+            tag_content = ''.join([ html.tostring(e, encoding=str) for e in tag ])
             if absolute_urls:
                 return self._change_relative_url_to_absolute(tag_content)
             return tag_content

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -e .
--e git+https://github.com/edx/xblock-utils.git@v1.1.0#egg=xblock-utils==1.1.0
-edx-i18n-tools==0.4.7
-lxml==3.0.1
-mako==1.0.7
-parsel==1.2.0
-transifex-client==0.13.4
+-e git+https://github.com/edx/xblock-utils.git@2.1.1#egg=xblock-utils==2.1.1
+edx-i18n-tools==0.5.3
+lxml==4.5.2
+mako==1.1.3
+parsel==1.6.0
+transifex-client==0.13.11

--- a/run_tests.py
+++ b/run_tests.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     from django.conf import settings
     settings.INSTALLED_APPS += ("image_explorer", )
 
-    for noisy_logger, log_level in logging_level_overrides.iteritems():
+    for noisy_logger, log_level in logging_level_overrides.items():
         logging.getLogger(noisy_logger).setLevel(log_level)
 
     from django.core.management import execute_from_command_line

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,12 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-image-explorer',
-    version='1.2',
+    version='2.0',
     description='XBlock - Image Explorer',
     packages=['image_explorer'],
     install_requires=[
         'XBlock>=1.2',
+        'parsel>=1.6.0,<=1.6.0',
     ],
     entry_points={
         'xblock.v1': 'image-explorer = image_explorer:ImageExplorerBlock',

--- a/tests/integration/test_image_explorer.py
+++ b/tests/integration/test_image_explorer.py
@@ -17,7 +17,7 @@ class TestImageExplorer(SeleniumXBlockTest):
         for h in hotspots:
             h.content = h.find_element_by_css_selector(".image-explorer-hotspot-reveal")
             h.close_button = h.find_element_by_css_selector(".image-explorer-close-reveal")
-            h.is_clickable = types.MethodType(lambda s: s.is_displayed() and s.is_enabled(), h, type(h))
+            h.is_clickable = types.MethodType(lambda s: s.is_displayed() and s.is_enabled(), h)
         return {h.get_attribute("data-item-id"): h for h in hotspots}
 
     def decorate_block(self, block):

--- a/tests/unit/test_image_explorer.py
+++ b/tests/unit/test_image_explorer.py
@@ -189,7 +189,7 @@ class TestImageExplorerBlock(unittest.TestCase):
         image_explorer_block._collect_video_elements(hotspot_with_videos, feedback)
 
         # check if feedback has video elements attached
-        self.assertTrue(feedback.has_key('youtube'))
+        self.assertTrue('youtube' in feedback)
         self.assertEqual(feedback.youtube.video_id, 'dmoZXcuozFQ')
-        self.assertTrue(feedback.has_key('bcove'))
+        self.assertTrue('bcove' in feedback)
         self.assertEqual(feedback.bcove.video_id, '1234')

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,17 @@
 [tox]
-envlist = unit,integration,quality,python3-quality
+envlist = unit,integration,python3-quality
 
 [testenv]
 whitelist_externals =
   make
 commands_pre =
-  pip install -e 'git://github.com/edx/xblock-sdk.git@v0.1.7#egg=xblock-sdk==0.1.7'
+  pip install -e 'git://github.com/edx/xblock-sdk.git@0.2.2#egg=xblock-sdk==0.2.2'
   make -C {envdir}/src/xblock-sdk/ install
   pip install -r requirements.txt
+
+  # upgrade both bok-choy and selenium to avoid BrokenPromise Error
+  # caused due to deprecated chromeOptions issue
+  pip install selenium==3.141.0 bok-choy==1.1.1
 
 [testenv:unit]
 commands =
@@ -17,10 +21,6 @@ commands =
 passenv = *
 commands =
   python run_tests.py tests/integration
-
-[testenv:quality]
-commands =
-  pylint image_explorer
 
 [testenv:python3-quality]
 commands =


### PR DESCRIPTION
Updates XBlock to support Python 3 so that it is compatible with edX's Juniper release.

Changes include PR #84 :+1: 

**JIRA tickets**: SE-3173

**Sandbox URL**: 
- LMS : https://xblock-image-explorer-test.opencraft.hosting/
- Studio: https://studio.xblock-image-explorer-test.opencraft.hosting/

**Testing instructions**:

1. Login to the LMS with `staff`
2. Open the Studio and make sure that you can add an Image XBlock to a Course
3. Make sure that the XBlock renders properly in Studio
4. Press _View Live_ and make sure that you can interact with the XBlock on the LMS 
5. Press _Preview_ and make sure that you can preview the XBlock properly

**Reviewers**
- [x] @toxinu
- [x] @shafqatfarhan 
- [x] @ihtram 