### PR TITLE
Add support for python3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,11 @@
-version: 2
+version: 2.1
 jobs:
   test:
+    parameters:
+      python_version:
+        type: string
     docker:
-      - image: circleci/python:2.7.16-browsers
+      - image: circleci/python:<< parameters.python_version >>-browsers
     steps:
       - checkout
       - run:
@@ -52,5 +55,8 @@ workflows:
   version: 2
   build:
     jobs:
-      - test
+      - test:
+          matrix:
+            parameters:
+              python_version: ["2.7.16", "3.5.7"]
       - quality

--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -354,7 +354,7 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
         Helper met
         """
         if tag is not None:
-            tag_content = u''.join(html.tostring(e) for e in tag)
+            tag_content = u''.join(html.tostring(e, encoding='unicode') for e in tag)
             if absolute_urls:
                 return self._change_relative_url_to_absolute(tag_content)
             return tag_content

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -e .
--e git+https://github.com/edx/xblock-utils.git@v1.1.0#egg=xblock-utils==1.1.0
+-e git+https://github.com/edx/xblock-utils.git@v1.2.3#egg=xblock-utils==1.2.3
 edx-i18n-tools==0.4.7
 lxml==3.0.1
 mako==1.0.7

--- a/run_tests.py
+++ b/run_tests.py
@@ -7,9 +7,11 @@ This script is required to run our selenium tests inside the xblock-sdk workbenc
 because the workbench SDK's settings file is not inside any python module.
 """
 
+from __future__ import absolute_import
 import os
 import sys
 import logging
+import six
 
 logging_level_overrides = {
     'workbench.views': logging.ERROR,
@@ -32,7 +34,7 @@ if __name__ == "__main__":
     from django.conf import settings
     settings.INSTALLED_APPS += ("image_explorer", )
 
-    for noisy_logger, log_level in logging_level_overrides.iteritems():
+    for noisy_logger, log_level in six.iteritems(logging_level_overrides):
         logging.getLogger(noisy_logger).setLevel(log_level)
 
     from django.core.management import execute_from_command_line

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-image-explorer',
-    version='1.2',
+    version='1.3',
     description='XBlock - Image Explorer',
     packages=['image_explorer'],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     packages=['image_explorer'],
     install_requires=[
         'XBlock>=1.2',
+        'parsel>=1.2.0',
     ],
     entry_points={
         'xblock.v1': 'image-explorer = image_explorer:ImageExplorerBlock',

--- a/tests/integration/test_image_explorer.py
+++ b/tests/integration/test_image_explorer.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import types
 
 from xblockutils.base_test import SeleniumXBlockTest

--- a/tests/integration/test_image_explorer.py
+++ b/tests/integration/test_image_explorer.py
@@ -18,7 +18,7 @@ class TestImageExplorer(SeleniumXBlockTest):
         for h in hotspots:
             h.content = h.find_element_by_css_selector(".image-explorer-hotspot-reveal")
             h.close_button = h.find_element_by_css_selector(".image-explorer-close-reveal")
-            h.is_clickable = types.MethodType(lambda s: s.is_displayed() and s.is_enabled(), h, type(h))
+            h.is_clickable = types.MethodType(lambda s: s.is_displayed() and s.is_enabled(), h)
         return {h.get_attribute("data-item-id"): h for h in hotspots}
 
     def decorate_block(self, block):

--- a/tests/unit/test_image_explorer.py
+++ b/tests/unit/test_image_explorer.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 from mock import patch
 from lxml import etree
@@ -189,7 +190,7 @@ class TestImageExplorerBlock(unittest.TestCase):
         image_explorer_block._collect_video_elements(hotspot_with_videos, feedback)
 
         # check if feedback has video elements attached
-        self.assertTrue(feedback.has_key('youtube'))
+        self.assertTrue('youtube' in feedback)
         self.assertEqual(feedback.youtube.video_id, 'dmoZXcuozFQ')
-        self.assertTrue(feedback.has_key('bcove'))
+        self.assertTrue('bcove' in feedback)
         self.assertEqual(feedback.bcove.video_id, '1234')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 # Test mocks and helpers
+from __future__ import absolute_import
 from mock import patch, MagicMock
 
 from xblock.runtime import DictKeyValueStore, KvsFieldData


### PR DESCRIPTION
I tried to install this on juniper devstack, and when I tried to create a component with this xblock, it failed with this error:

```python
juniper-devstack.studio |   File "/edx/src/xblock-image-explorer/image_explorer/image_explorer.py", line 357, in _inner_content
juniper-devstack.studio |     tag_content = u''.join(html.tostring(e) for e in tag)
juniper-devstack.studio | TypeError: sequence item 0: expected str instance, bytes found
```
Fortunately, this was the only change that I needed to have this xblock working, I also added to setup.py parsel as a requirement in order to prevent the error:

```python
juniper-devstack.studio | 2020-12-04 20:30:42,574 WARNING 239 [xblock.plugin] [user None] plugin.py:147 - Unable to load XBlock 'image-explorer'
juniper-devstack.studio | Traceback (most recent call last):
juniper-devstack.studio |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/xblock/plugin.py", line 144, in load_classes
juniper-devstack.studio |     yield (class_.name, cls._load_class_entry_point(class_))
juniper-devstack.studio |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/xblock/plugin.py", line 73, in _load_class_entry_point
juniper-devstack.studio |     class_ = entry_point.load()
juniper-devstack.studio |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2447, in load
juniper-devstack.studio |     return self.resolve()
juniper-devstack.studio |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2453, in resolve
juniper-devstack.studio |     module = __import__(self.module_name, fromlist=['__name__'], level=0)
juniper-devstack.studio |   File "/edx/src/xblock-image-explorer/image_explorer/__init__.py", line 25, in <module>
juniper-devstack.studio |     from .image_explorer import ImageExplorerBlock
juniper-devstack.studio |   File "/edx/src/xblock-image-explorer/image_explorer/image_explorer.py", line 34, in <module>
juniper-devstack.studio |     from parsel import Selector
juniper-devstack.studio | ImportError: No module named 'parsel'
```